### PR TITLE
make autocut.modelPath optional

### DIFF
--- a/sciencebeam-autocut/templates/deployment.yaml
+++ b/sciencebeam-autocut/templates/deployment.yaml
@@ -25,8 +25,10 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ['start-autocut.sh']
           env:
+          {{- if .Values.autocut.modelPath }}
           - name: AUTOCUT_MODEL_PATH
             value: "{{ .Values.autocut.modelPath }}"
+          {{- end }}
           - name: GUNICORN_WORKERS
             value: "{{ .Values.autocut.workers }}"
           ports:

--- a/sciencebeam-autocut/templates/deployment.yaml
+++ b/sciencebeam-autocut/templates/deployment.yaml
@@ -25,12 +25,12 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ['start-autocut.sh']
           env:
-          {{- if .Values.autocut.modelPath }}
-          - name: AUTOCUT_MODEL_PATH
-            value: "{{ .Values.autocut.modelPath }}"
-          {{- end }}
           - name: GUNICORN_WORKERS
             value: "{{ .Values.autocut.workers }}"
+          {{ if .Values.autocut.modelPath }}
+          - name: AUTOCUT_MODEL_PATH
+            value: "{{ .Values.autocut.modelPath }}"
+          {{ end }}
           ports:
             - name: http
               containerPort: 8080


### PR DESCRIPTION
@giorgiosironi any idea why it still seem to set AUTOCUT_MODEL_PATH to an empty string?

I believe it should evaluate as falsy as per the [docs](https://github.com/helm/helm/blob/master/docs/chart_template_guide/control_structures.md):

> A pipeline is evaluated as _false_ if the value is:
> 
> - a boolean false
> - a numeric zero
> - an empty string
> - a `nil` (empty or null)
> - an empty collection (`map`, `slice`, `tuple`, `dict`, `array`)

From the spec json:

```json
                "env": [
                    {
                        "name": "AUTOCUT_MODEL_PATH"
                    },
```