### PR TITLE
exposed grobid env

### DIFF
--- a/grobid/templates/deployment.yaml
+++ b/grobid/templates/deployment.yaml
@@ -32,6 +32,10 @@ spec:
           env:
           - name: JAVA_OPTS
             value: "{{ .Values.maxJavaHeap }}"
+        {{- range $key, $value := .Values.env }}
+          - name: {{ $key }}
+            value: "{{ $value }}"
+        {{- end }}
           ports:
             - name: http
               containerPort: 8070

--- a/grobid/values.yaml
+++ b/grobid/values.yaml
@@ -56,3 +56,5 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+env: {}


### PR DESCRIPTION
Env properties can be set from Helm, e.g.:

```bash
helm upgrade --install --wait "grobid" \
    --set "env.DISABLE_LMDB_CACHE=1" \
    ./grobid
```