### PR TITLE
made warmup image and document url configurable

### DIFF
--- a/grobid/templates/deployment.yaml
+++ b/grobid/templates/deployment.yaml
@@ -64,7 +64,7 @@ spec:
                   - '/bin/sh'
                   - '-c'
                   - 'curl -v --form input=@sample.pdf --form consolidateHeader=0 --form consolidateCitations=0 -o /dev/null http://localhost:8070/api/processFulltextDocument'
-            periodSeconds: 60
+            periodSeconds: {{ .Values.warmup.periodSeconds }}
         {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/grobid/templates/deployment.yaml
+++ b/grobid/templates/deployment.yaml
@@ -54,7 +54,8 @@ spec:
             {{- toYaml .Values.resources | nindent 12 }}
         {{- if .Values.warmup.enabled }}
         - name: warmup
-          image: pstauffer/curl
+          image: "{{ .Values.warmup.image.repository }}:{{ .Values.warmup.image.tag }}"
+          imagePullPolicy: {{ .Values.warmup.image.pullPolicy }}
           command: ['/bin/sh']
           args: ['-c', 'curl https://upload.wikimedia.org/wikipedia/commons/5/5b/I-20_Sample.pdf -o sample.pdf && sleep 168h']
           readinessProbe:

--- a/grobid/templates/deployment.yaml
+++ b/grobid/templates/deployment.yaml
@@ -57,7 +57,7 @@ spec:
           image: "{{ .Values.warmup.image.repository }}:{{ .Values.warmup.image.tag }}"
           imagePullPolicy: {{ .Values.warmup.image.pullPolicy }}
           command: ['/bin/sh']
-          args: ['-c', 'curl https://upload.wikimedia.org/wikipedia/commons/5/5b/I-20_Sample.pdf -o sample.pdf && sleep 168h']
+          args: ['-c', 'curl "{{ .Values.warmup.documentUrl }}" -o sample.pdf && sleep 168h']
           readinessProbe:
             exec:
               command:

--- a/grobid/values.yaml
+++ b/grobid/values.yaml
@@ -55,6 +55,7 @@ autoscaling:
 
 warmup:
   enabled: false
+  periodSeconds: 60
   # the url to the sample document (submitted to the service)
   documentUrl: "https://upload.wikimedia.org/wikipedia/commons/5/5b/I-20_Sample.pdf"
   # the warmup image, must have curl installed

--- a/grobid/values.yaml
+++ b/grobid/values.yaml
@@ -55,6 +55,9 @@ autoscaling:
 
 warmup:
   enabled: false
+  # the url to the sample document (submitted to the service)
+  documentUrl: "https://upload.wikimedia.org/wikipedia/commons/5/5b/I-20_Sample.pdf"
+  # the warmup image, must have curl installed
   image:
     repository: pstauffer/curl
     tag: latest

--- a/grobid/values.yaml
+++ b/grobid/values.yaml
@@ -55,6 +55,10 @@ autoscaling:
 
 warmup:
   enabled: false
+  image:
+    repository: pstauffer/curl
+    tag: latest
+    pullPolicy: IfNotPresent
 
 nodeSelector: {}
 


### PR DESCRIPTION
part of https://github.com/elifesciences/sciencebeam-issues/issues/220

By making the image and the document url configurable, a newer or alternative image can be installed.
One could also configure a more comprehensive document or one that may not require https.